### PR TITLE
54 buttons missing aria labels across multiple page

### DIFF
--- a/frontend/template/explore.html
+++ b/frontend/template/explore.html
@@ -92,7 +92,7 @@
           <p class="card-text">Sunset views just beside UWA campus are absolutely stunning...</p>
           <div class="d-flex align-items-center justify-content-between mt-2">
             <small class="text-muted">perthwanderer</small>
-            <button class="btn btn-sm btn-outline-secondary btn-fav">Favourite</button>
+            <button class="btn btn-sm btn-outline-secondary btn-fav" aria-label="Add to favourites">Favourite</button>
           </div>
         </div>
         <div class="card-footer bg-transparent border-0 pt-0">
@@ -112,7 +112,7 @@
           <p class="card-text">Wildflower season is breathtaking — absolutely worth the visit!</p>
           <div class="d-flex align-items-center justify-content-between mt-2">
             <small class="text-muted">sunset_chaser</small>
-            <button class="btn btn-sm btn-outline-secondary btn-fav">Favourite</button>
+            <button class="btn btn-sm btn-outline-secondary btn-fav" aria-label="Add to favourites">Favourite</button>
           </div>
         </div>
         <div class="card-footer bg-transparent border-0 pt-0">
@@ -132,7 +132,7 @@
           <p class="card-text">Best gelato in Perth — always a queue but absolutely worth the wait...</p>
           <div class="d-flex align-items-center justify-content-between mt-2">
             <small class="text-muted">uwa_foodie</small>
-            <button class="btn btn-sm btn-outline-secondary btn-fav">Favourite</button>
+            <button class="btn btn-sm btn-outline-secondary btn-fav" aria-label="Add to favourites">Favourite</button>
           </div>
         </div>
         <div class="card-footer bg-transparent border-0 pt-0">
@@ -152,7 +152,7 @@
           <p class="card-text">Best study spot on campus — especially level 4 with the views...</p>
           <div class="d-flex align-items-center justify-content-between mt-2">
             <small class="text-muted">studyspot_hunter</small>
-            <button class="btn btn-sm btn-outline-secondary btn-fav">Favourite</button>
+            <button class="btn btn-sm btn-outline-secondary btn-fav" aria-label="Add to favourites">Favourite</button>
           </div>
         </div>
         <div class="card-footer bg-transparent border-0 pt-0">

--- a/frontend/template/index.html
+++ b/frontend/template/index.html
@@ -57,7 +57,7 @@
             </p>
             <div class="d-flex align-items-center justify-content-between mt-2">
               <small class="text-muted">{{ check_in.user_id }}</small>
-              <button class="btn btn-sm btn-outline-secondary btn-fav">Favourite</button>
+              <button class="btn btn-sm btn-outline-secondary btn-fav" aria-label="Add to favourites">Favourite</button>
             </div>
           </div>
           <div class="card-footer bg-transparent border-0 pt-0">
@@ -79,7 +79,7 @@
           <p class="card-text">Sunset views just beside UWA campus are absolutely stunning...</p>
           <div class="d-flex align-items-center justify-content-between mt-2">
             <small class="text-muted">perthwanderer</small>
-            <button class="btn btn-sm btn-outline-secondary btn-fav">Favourite</button>
+            <button class="btn btn-sm btn-outline-secondary btn-fav" aria-label="Add to favourites">Favourite</button>
           </div>
         </div>
         <div class="card-footer bg-transparent border-0 pt-0">
@@ -99,7 +99,7 @@
           <p class="card-text">Wildflower season is breathtaking — absolutely worth the visit!</p>
           <div class="d-flex align-items-center justify-content-between mt-2">
             <small class="text-muted">sunset_chaser</small>
-            <button class="btn btn-sm btn-outline-secondary btn-fav">Favourite</button>
+            <button class="btn btn-sm btn-outline-secondary btn-fav" aria-label="Add to favourites">Favourite</button>
           </div>
         </div>
         <div class="card-footer bg-transparent border-0 pt-0">
@@ -119,7 +119,7 @@
           <p class="card-text">Best gelato in Perth — always a queue but absolutely worth the wait...</p>
           <div class="d-flex align-items-center justify-content-between mt-2">
             <small class="text-muted">uwa_foodie</small>
-            <button class="btn btn-sm btn-outline-secondary btn-fav">Favourite</button>
+            <button class="btn btn-sm btn-outline-secondary btn-fav" aria-label="Add to favourites">Favourite</button>
           </div>
         </div>
         <div class="card-footer bg-transparent border-0 pt-0">
@@ -139,7 +139,7 @@
           <p class="card-text">Best study spot on campus — especially level 4 with the views...</p>
           <div class="d-flex align-items-center justify-content-between mt-2">
             <small class="text-muted">studyspot_hunter</small>
-            <button class="btn btn-sm btn-outline-secondary btn-fav">Favourite</button>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
         </div>
         <div class="card-footer bg-transparent border-0 pt-0">

--- a/frontend/template/profile.html
+++ b/frontend/template/profile.html
@@ -123,7 +123,7 @@
             </div>
             <div class="card-footer bg-transparent border-0 d-flex gap-2">
               <a href="checkin_details.html" class="btn btn-sm btn-outline-secondary flex-grow-1">View</a>
-              <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+              <button class="btn btn-sm btn-outline-danger" aria-label="Delete check-in"><i class="bi bi-trash"></i></button>
             </div>
           </div>
         </div>
@@ -146,7 +146,7 @@
             </div>
             <div class="card-footer bg-transparent border-0 d-flex gap-2">
               <a href="checkin_details.html" class="btn btn-sm btn-outline-secondary flex-grow-1">View</a>
-              <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+              <button class="btn btn-sm btn-outline-danger" aria-label="Delete check-in"><i class="bi bi-trash"></i></button>
             </div>
           </div>
         </div>
@@ -169,7 +169,7 @@
             </div>
             <div class="card-footer bg-transparent border-0 d-flex gap-2">
               <a href="checkin_details.html" class="btn btn-sm btn-outline-secondary flex-grow-1">View</a>
-              <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+              <button class="btn btn-sm btn-outline-danger" aria-label="Delete check-in"><i class="bi bi-trash"></i></button>
             </div>
           </div>
         </div>
@@ -192,7 +192,7 @@
             </div>
             <div class="card-footer bg-transparent border-0 d-flex gap-2">
               <a href="checkin_details.html" class="btn btn-sm btn-outline-secondary flex-grow-1">View</a>
-              <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+              <button class="btn btn-sm btn-outline-danger" aria-label="Delete check-in"><i class="bi bi-trash"></i></button>
             </div>
           </div>
         </div>
@@ -215,7 +215,7 @@
             </div>
             <div class="card-footer bg-transparent border-0 d-flex gap-2">
               <a href="checkin_details.html" class="btn btn-sm btn-outline-secondary flex-grow-1">View</a>
-              <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+              <button class="btn btn-sm btn-outline-danger" aria-label="Delete check-in"><i class="bi bi-trash"></i></button>
             </div>
           </div>
         </div>
@@ -237,7 +237,7 @@
             </div>
             <div class="card-footer bg-transparent border-0 d-flex gap-2">
               <a href="checkin_details.html" class="btn btn-sm btn-outline-secondary flex-grow-1">View</a>
-              <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+              <button class="btn btn-sm btn-outline-danger" aria-label="Delete check-in"><i class="bi bi-trash"></i></button>
             </div>
           </div>
         </div>
@@ -275,7 +275,7 @@
             </div>
             <div class="card-footer bg-transparent border-0 d-flex gap-2">
               <a href="checkin_details.html" class="btn btn-sm btn-outline-secondary flex-grow-1">View</a>
-              <button class="btn btn-sm btn-outline-secondary btn-fav text-danger">
+              <button class="btn btn-sm btn-outline-secondary btn-fav text-danger" aria-label="Remove from saved">
                 <i class="bi bi-heart-fill"></i>
               </button>
             </div>
@@ -300,7 +300,7 @@
             </div>
             <div class="card-footer bg-transparent border-0 d-flex gap-2">
               <a href="checkin_details.html" class="btn btn-sm btn-outline-secondary flex-grow-1">View</a>
-              <button class="btn btn-sm btn-outline-secondary btn-fav text-danger">
+              <button class="btn btn-sm btn-outline-secondary btn-fav text-danger" aria-label="Remove from saved">
                 <i class="bi bi-heart-fill"></i>
               </button>
             </div>
@@ -325,7 +325,7 @@
             </div>
             <div class="card-footer bg-transparent border-0 d-flex gap-2">
               <a href="checkin_details.html" class="btn btn-sm btn-outline-secondary flex-grow-1">View</a>
-              <button class="btn btn-sm btn-outline-secondary btn-fav text-danger">
+              <button class="btn btn-sm btn-outline-secondary btn-fav text-danger" aria-label="Remove from saved">
                 <i class="bi bi-heart-fill"></i>
               </button>
             </div>
@@ -349,7 +349,7 @@
             </div>
             <div class="card-footer bg-transparent border-0 d-flex gap-2">
               <a href="checkin_details.html" class="btn btn-sm btn-outline-secondary flex-grow-1">View</a>
-              <button class="btn btn-sm btn-outline-secondary btn-fav text-danger">
+              <button class="btn btn-sm btn-outline-secondary btn-fav text-danger" aria-label="Remove from saved">
                 <i class="bi bi-heart-fill"></i>
               </button>
             </div>


### PR DESCRIPTION
This PR fixes missing aria-labels on interactive buttons across multiple pages:

index.html Added aria-label="Add to favourites" to all 4 Favourite buttons
explore.html Added aria-label="Add to favourites" to all 4 Favourite buttons  
profile.html  Added aria-label="Delete check-in" to all 6 Delete buttons
 profile.html Added aria-label="Remove from saved" to all 4 Heart buttons

Screen readers can now correctly announce these buttons to users 
with visual impairments.

Closes #54.