### PR TITLE
fix(explore): wire search form and remove static pagination

### DIFF
--- a/frontend/template/explore.html
+++ b/frontend/template/explore.html
@@ -25,8 +25,10 @@
         <p class="text-muted mb-0 mt-1 small">Discover places around Perth &amp; UWA</p>
       </div>
       <div class="col-md-6">
-        <form class="d-flex">
+        <form class="d-flex" action="{{ url_for('search') }}" method="GET">
           <input type="text" class="form-control me-2"
+                 name="q"
+                 value="{{ search_query | default('') }}"
                  placeholder="Search by place name or description..." />
           <button class="btn btn-pp px-3" type="submit">Search</button>
         </form>
@@ -95,18 +97,6 @@
     {% endfor %}
 
   </div><!-- /row -->
-
-
-  <!-- PAGINATION -->
-  <nav class="mt-5" aria-label="Page navigation">
-    <ul class="pagination justify-content-center">
-      <li class="page-item disabled"><a class="page-link" href="#">Previous</a></li>
-      <li class="page-item active"><a class="page-link" href="#">1</a></li>
-      <li class="page-item"><a class="page-link" href="#">2</a></li>
-      <li class="page-item"><a class="page-link" href="#">3</a></li>
-      <li class="page-item"><a class="page-link" href="#">Next</a></li>
-    </ul>
-  </nav>
 
 </main>
 


### PR DESCRIPTION
- Submit the Explore page search field to the existing search route

- Preserve the entered search query in the page header form

- Remove prototype pagination now that cards are database-backed