### PR TITLE
 added custom branded 404 and 500 error pages

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -399,5 +399,16 @@ def navbar():
     return render_template("navbar.html")
 
 
+@app.errorhandler(404)
+def not_found(error):
+    return render_template("404.html"), 404
+
+
+@app.errorhandler(500)
+def internal_error(error):
+    db.session.rollback()
+    return render_template("500.html"), 500
+
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/frontend/template/404.html
+++ b/frontend/template/404.html
@@ -6,7 +6,7 @@
   <title>Page Not Found — PerthPins</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
-  <link rel="stylesheet" href="../static/css/common.css" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}" />
 </head>
 <body>
 {% include "navbar.html" %}

--- a/frontend/template/404.html
+++ b/frontend/template/404.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Page Not Found — PerthPins</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+  <link rel="stylesheet" href="../static/css/common.css" />
+</head>
+<body>
+{% include "navbar.html" %}
+<div class="d-flex flex-column align-items-center justify-content-center
+            text-center py-5 mt-5">
+  <i class="bi bi-geo-alt-fill text-success" style="font-size:4rem;"></i>
+  <h1 class="display-4 fw-bold mt-3">404</h1>
+  <p class="lead text-muted">This pin doesn't exist on the map.</p>
+  <p class="text-muted small">
+    The page you're looking for may have been moved or deleted.
+  </p>
+  <a href="{{ url_for('index') }}" class="btn btn-pp mt-3">
+    <i class="bi bi-house me-1"></i>Back to Home
+  </a>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/frontend/template/500.html
+++ b/frontend/template/500.html
@@ -6,7 +6,7 @@
   <title>Server Error — PerthPins</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
-  <link rel="stylesheet" href="../static/css/common.css" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}" />
 </head>
 <body>
 {% include "navbar.html" %}

--- a/frontend/template/500.html
+++ b/frontend/template/500.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Server Error — PerthPins</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
+  <link rel="stylesheet" href="../static/css/common.css" />
+</head>
+<body>
+{% include "navbar.html" %}
+<div class="d-flex flex-column align-items-center justify-content-center
+            text-center py-5 mt-5">
+  <i class="bi bi-exclamation-triangle-fill text-warning" style="font-size:4rem;"></i>
+  <h1 class="display-4 fw-bold mt-3">500</h1>
+  <p class="lead text-muted">Something went wrong on our end.</p>
+  <p class="text-muted small">
+    We have been notified. Please try again in a moment.
+  </p>
+  <a href="{{ url_for('index') }}" class="btn btn-pp mt-3">
+    <i class="bi bi-house me-1"></i>Back to Home
+  </a>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Both pages use existing navbar and common.css so they match app branding. 
Map-pin icon for 404 and warning triangle for 500. Each includes a Back to Home button. 
Flask error handlers registered in app.py.


closes #94 