### PR TITLE
fix(frontend): hide unfinished share button and remove legacy loader

### DIFF
--- a/frontend/static/js/common.js
+++ b/frontend/static/js/common.js
@@ -1,11 +1,5 @@
-function loadComponent(id, file) {
-  fetch(file)
-    .then(function(res) { return res.text(); })
-    .then(function(html) {
-      document.getElementById(id).innerHTML = html;
-      // Highlight the active nav link based on the current page filename
-      var page = window.location.pathname.split('/').pop() || 'index.html';
-      var link = document.querySelector('#' + id + ' .nav-link[href="' + page + '"]');
-      if (link) link.classList.add('active');
-    });
-}
+// Shared frontend helpers.
+//
+// The old prototype navbar loader injected fetched HTML into the page.
+// Pages now render the navbar with Jinja includes, so that loader is no
+// longer needed and is intentionally left out.

--- a/frontend/template/checkin_details.html
+++ b/frontend/template/checkin_details.html
@@ -126,9 +126,7 @@
             <i class="bi bi-heart me-1"></i>Favourite
           </a>
           {% endif %}
-          <button type="button" class="btn btn-sm btn-outline-secondary">
-            <i class="bi bi-share me-1"></i>Share
-          </button>
+          {# Share action is hidden until a real sharing flow is implemented. #}
         </div>
       </div>
 


### PR DESCRIPTION
- Hide the inactive Share button on the check-in detail page
- Remove the unused prototype navbar loader from common.js