### PR TITLE
Add rating and link details to popup markers

### DIFF
--- a/frontend/static/js/home.js
+++ b/frontend/static/js/home.js
@@ -18,10 +18,26 @@ markerData.forEach(function(m) {
   category.className = 'perthpins-popup-category';
   category.textContent = m.category || 'Uncategorised';
 
+  const rating = document.createElement('div');
+  rating.className = 'perthpins-popup-rating';
+  rating.textContent = m.rating ? `Rating: ${m.rating} / 5` : 'Not rated yet';
+
+  const link = document.createElement('a');
+  link.href = `/checkin/${m.id}`;
+  link.textContent = 'View Details →';
+  link.style.fontSize = '0.82rem';
+
   popup.appendChild(title);
   popup.appendChild(category);
+  popup.appendChild(rating);
+  popup.appendChild(link);
 
   L.marker([m.lat, m.lng])
     .addTo(map)
     .bindPopup(popup);
 });
+
+if (markerData.length > 0) {
+  const bounds = markerData.map(m => [m.lat, m.lng]);
+  map.fitBounds(bounds, { padding: [40, 40] });
+}


### PR DESCRIPTION
- Add rating display to map popups : shows "Rating: X / 5" or "Not rated yet"
- Add "View Details : " link in popup linking directly to the check-in detail page
- Auto-fit map bounds to all markers on load so all check-ins are visible without manual panning